### PR TITLE
add license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,10 +5,9 @@
    between you (the “Licensee” or “you”) and Dublin City
    University of Collins Avenue, Glasnevin, Dublin 9, Ireland (the
    “Licensor”, “DCU”, “us” or “we”) for James Barry’s multilingual
-   parsing in any version publsihed on
-   https://github.com/Jbar-ry/multilingual-parsing that contains
-   this licence in a file “LICENSE.txt” in the repository’s main
-   folder (the “Software”).
+   parsing in any version published or distributed with this
+   licence in a file “LICENSE.txt” present in its main folder (the
+   “Software”).
 
    IMPORTANT NOTICE TO ALL USERS:
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,160 @@
+
+                           Software Licence
+
+   This licence agreement (the “Licence”) is a legal agreement
+   between you (the “Licensee” or “you”) and Dublin City
+   University of Collins Avenue, Glasnevin, Dublin 9, Ireland (the
+   “Licensor”, “DCU”, “us” or “we”) for James Barry’s multilingual
+   parsing in any version publsihed on
+   https://github.com/Jbar-ry/multilingual-parsing that contains
+   this licence in a file “LICENSE.txt” in the repository’s main
+   folder (the “Software”).
+
+   IMPORTANT NOTICE TO ALL USERS:
+
+   BY USING THE SOFTWARE, YOU AGREE TO BE BOUND BY THE TERMS OF
+   THIS LICENCE. IF YOU DO NOT AGREE TO THE TERMS OF THIS LICENCE,
+   DO NOT USE THE SOFTWARE.
+
+   Grant and scope of licence
+    1. In consideration of your agreeing to abide by the terms of
+       this Licence, the Licensor hereby grants to you a
+       non-exclusive, non-transferable, non-sub-licensable,
+       revocable licence to use the Software for non-commercial
+       purposes on the terms of this Licence.
+    2. If you intend on using the Software for commercial
+       purposes, you must obtain a commercial licence from the DCU
+       Invent. For further information please contact
+       info@invent.dcu.ie.
+
+   Restrictions
+    3. Except as expressly set out in this Licence, you undertake:
+         1. not to use the Software for commercial purposes;
+         2. not to translate the Software into any computer
+            language aside from the current source code language;
+            and
+         3. not to rent, lease, sub-license or loan the Software.
+
+   Obligations
+    4. You undertake and warrant:
+         1. To reference your use of the Software in any
+            publications or academic research which is based or
+            partly based on findings obtained using the Software
+            including where the Software is used to gather data or
+            information used in such publications or academic
+            research. Your obligations under this clause will be
+            met where you include wording along the following
+            lines in your publication or academic research:
+            “[Software Name, Version] used under licence from
+            ADAPT at Dublin City University through SF I Grant
+            Number 13/RC/2106”.
+         2. Any additions, updates, amendments, modifications,
+            adaptions or improvements which you make to all or
+            part of the source code of the Software (including but
+            not limited to the use of application programming
+            interfaces (API’s)) (“Improvements”) will
+            automatically be owned by Licensor. To the extent that
+            they are not automatically owned by DCU, you hereby
+            irrevocably assign all Improvements to DCU.
+
+   Intellectual property rights
+    5. You acknowledge that all intellectual property rights in
+       the Software throughout the world belong to the Licensor,
+       that rights in the Software are licensed (not sold) to you,
+       and that you have no rights in, or to, the Software other
+       than the right to use them in accordance with the terms of
+       this Licence.
+
+   No Warranty
+    6. You acknowledge that any the Software is provided to you on
+       an "as is" basis now and in the future. All conditions,
+       warranties or other terms which might have effect between
+       the parties or be implied or incorporated into this licence
+       or any collateral contract, whether by statute, common law
+       or otherwise, are hereby excluded to the maximum extent
+       permitted by law, including the implied conditions,
+       warranties or other terms as to satisfactory quality,
+       fitness for purpose or the use of reasonable skill and care
+       in the preparation of the Software.
+    7. You acknowledge that the Software may not be free of errors
+       or bugs. DCU has no obligation to support or update the
+       Software in any way.
+
+   Limitation of Liability
+    8. You acknowledge that the Software has not been developed to
+       meet your individual requirements and that it is therefore
+       your responsibility to ensure that the facilities and
+       functions of the Software meet your requirements.
+    9. We shall not under any circumstances whatever be liable to
+       you, whether in contract, tort (including negligence),
+       breach of statutory duty, or otherwise, arising under or in
+       connection with the Licence for loss of profits, sales,
+       business, or revenue, business interruption, loss of
+       anticipated savings, loss or corruption of data or
+       information, loss of business opportunity, goodwill or
+       reputation or any indirect or consequential loss or damage.
+   10. Other than the losses set out in term 9 (for which we are
+       not liable), our maximum aggregate liability under or in
+       connection with this Licence whether in contract, tort
+       (including negligence) or otherwise, shall in all
+       circumstances be limited to a sum equal to the total fees
+       paid by the Licensee to DCU. This maximum cap does not
+       apply to term 11.
+   11. Nothing in this Licence shall limit or exclude our
+       liability for death or personal injury resulting from our
+       negligence, fraud or fraudulent misrepresentation or any
+       other liability that cannot be excluded or limited by Irish
+       law.
+   12. This Licence sets out the full extent of our obligations
+       and liabilities in respect of the supply of the Software.
+       Except as expressly stated in this Licence, there are no
+       conditions, warranties, representations or other terms,
+       express or implied, that are binding on us. Any condition,
+       warranty, representation or other term concerning the
+       supply of the Software which might otherwise be implied
+       into, or incorporated in, this Licence whether by statute,
+       common law or otherwise, is excluded to the fullest extent
+       permitted by law.
+
+   Termination
+   13. We may terminate this Licence immediately by written notice
+       to you if you commit a breach of this Licence which you
+       fail to remedy (if remediable) within 14 days after the
+       service on you of written notice requiring you to do so.
+   14. Upon termination for any reason:
+         1. all rights granted to you under this Licence shall
+            cease;
+         2. you must cease all activities authorised by this
+            Licence; and
+         3. you must immediately delete or remove the Software
+            from all computer equipment in your possession or
+            under your control.
+
+   Other Important Terms
+   15. We may transfer our rights and obligations under this
+       Licence to another organisation, but this will not affect
+       your rights or our obligations under this Licence.
+   16. You may only transfer your rights or your obligations under
+       this Licence to another person if you obtain our prior
+       consent in writing to do so.
+   17. This Licence constitutes the entire agreement between you
+       and us. You acknowledge that you have not relied on any
+       statement, promise or representation made or given by or on
+       behalf of us which is not set out in this Licence.
+   18. If we fail to insist that you perform any of your
+       obligations under this Licence, or if we do not enforce our
+       rights against you, or if we delay in doing so, that will
+       not mean that we have waived our rights against you and
+       will not mean that you do not have to comply with those
+       obligations. If we do waive a default by you, we will only
+       do so in writing, and that will not mean that we will
+       automatically waive any later default by you.
+   19. Each of the conditions of this Licence operates separately.
+       If any court or competent authority decides that any of
+       them are unlawful or unenforceable, the remaining
+       conditions will remain in full force and effect.
+   20. This Licence, its subject matter and its formation, are
+       governed by Irish law. You and we both agree to that the
+       courts of Ireland will have exclusive jurisdiction.
+
+                                  3


### PR DESCRIPTION
Address issue #1 by adding the license Adapt Non-commercial Licence as received from ADAPT IP manager 2019-07-24 and the field "Name and Version" populated with
>  "James Barry’s multilingual
>   parsing in any version published or distributed with this
>   licence in a file “LICENSE.txt” present in its main folder"

The `.docx` format has been converted to `.html` using LibreOffice and then converted to `.txt` using the `lynx` command line web browser.